### PR TITLE
Fix for current issue where the dist files are in arbitrary sub directories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,10 @@ RUN buildDeps='curl'; \
     curl -sL 'https://github.com/taigaio/taiga-front-dist/tarball/stable' | tar xz -C taiga-front-dist --strip-components=1 && \
     cd taiga-front-dist && \
 
+    # Handle case where distribution has files in arbitrary sub-directory
+    tmpSource=`find dist -type d -name js | sed -r 's|/[^/]+$|/*|'` && \
+    if [ "$tmpSource" != 'dist/*' ]; then mv $tmpSource dist/; fi && \
+
     # clean up
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     apt-get purge -y --auto-remove $buildDeps && \


### PR DESCRIPTION
The current taiga-front is now placing the stable source files in a "version" folder inside dist (currently named v-1454396495445) causing your start script to fail on line 15 where it is looking to use files that are not present.  

This modification will move all sub-folders to the version folder back where they are expected to be for your start script, regardless of the name of the version folder.
